### PR TITLE
Use `islice` to grab specific lines from files, minor formatting

### DIFF
--- a/mellon/factories/filesystem/tests/test_file.py
+++ b/mellon/factories/filesystem/tests/test_file.py
@@ -3,6 +3,8 @@ import os
 import os.path
 import shutil
 import unittest
+from itertools import islice
+
 import zope.testrunner
 from zope import component
 from sparc.testing.fixture import test_suite_mixin
@@ -17,172 +19,147 @@ class MellonFactoryFilesystemFileTestCase(unittest.TestCase):
     sm = component.getSiteManager()
 
     def test_recursive_dir(self):
-        mf_provider = component.createObject(\
+        mf_provider = component.createObject(
             u'mellon.factories.filesystem.file_provider_for_recursive_directory_config',
             self.layer.config)
-        #import pdb;pdb.set_trace()
+        # import pdb;pdb.set_trace()
         mf_files = list(mf_provider)
         self.assertEquals(len(mf_files), 8)
-    
+
     def test_small_files(self):
-        #Unicode
+        # Unicode
         mf_unicode = component.createObject(
-                            u'mellon.factories.filesystem.unicode_file',
-                            os.path.join(self.layer.working_dir, 'small.txt'),
-                            self.layer.config)
-        snippets = [s for s in mf_unicode]
+            u'mellon.factories.filesystem.unicode_file',
+            os.path.join(self.layer.working_dir, 'small.txt'),
+            self.layer.config)
+        snippets = list(mf_unicode)
         self.assertEquals(len(snippets), 1)
         self.assertEquals(snippets[0].data, u'1\n2\n3\n4\n')
-        #Binary
+        # Binary
         path = os.path.join(self.layer.working_dir, 'small.bin')
-        with open(path,'rb') as file:
+        with open(path, 'rb') as file:
             contents = file.read()
         mf_binary = component.createObject(
-                            u'mellon.factories.filesystem.byte_file',
-                            path,
-                            self.layer.config)
-        snippets = [s for s in mf_binary]
+            u'mellon.factories.filesystem.byte_file',
+            path,
+            self.layer.config)
+        snippets = list(mf_binary)
         self.assertEquals(len(snippets), 1)
         self.assertEquals(snippets[0].data, contents)
 
     def test_exact_files(self):
-        #Unicode
+        # Unicode
         mf_unicode = component.createObject(
-                            u'mellon.factories.filesystem.unicode_file',
-                            os.path.join(self.layer.working_dir,'1','a','exact.txt'),
-                            self.layer.config)
-        snippets = [s for s in mf_unicode]
+            u'mellon.factories.filesystem.unicode_file',
+            os.path.join(self.layer.working_dir, '1', 'a', 'exact.txt'),
+            self.layer.config)
+        snippets = list(mf_unicode)
         self.assertEquals(len(snippets), 1)
-        self.assertEquals(snippets[0].data[0:1], u'1')
-        self.assertEquals(snippets[0].data[-2:len(snippets[0].data)], u"5\n")
-        #Binary
-        path = os.path.join(self.layer.working_dir,'1','a','exact.bin')
-        with open(path,'rb') as file:
+        self.assertTrue(snippets[0].data.startswith(u'1'))
+        self.assertTrue(snippets[0].data.endswith(u"5\n"))
+        # Binary
+        path = os.path.join(self.layer.working_dir, '1', 'a', 'exact.bin')
+        with open(path, 'rb') as file:
             contents = file.read()
         mf_binary = component.createObject(
-                            u'mellon.factories.filesystem.byte_file',
-                            path,
-                            self.layer.config)
-        snippets = [s for s in mf_binary]
+            u'mellon.factories.filesystem.byte_file',
+            path,
+            self.layer.config)
+        snippets = list(mf_binary)
         self.assertEquals(len(snippets), 1)
         self.assertEquals(snippets[0].data, contents)
 
     def test_larger_unicode_files(self):
-        #Unicode
-        path = os.path.join(self.layer.working_dir,'2','d','larger.txt')
-        with open(path,'rt') as file:
+        # Unicode
+        path = os.path.join(self.layer.working_dir, '2', 'd', 'larger.txt')
+        with open(path, 'rt') as file:
             contents = file.read()
         mf_unicode = component.createObject(
-                            u'mellon.factories.filesystem.unicode_file',
-                            path,
-                            self.layer.config)
-        snippets = [s for s in mf_unicode]
-        self.assertEquals(len(snippets), 3) # remember we'll be re-reading data each snippet
+            u'mellon.factories.filesystem.unicode_file',
+            path,
+            self.layer.config)
+        snippets = list(mf_unicode)
+        self.assertEquals(len(snippets), 3)  # remember we'll be re-reading data each snippet
         # test first snippet
-        with open(path,'rt') as file:
-            contents = u""
-            for i in range(5):
-                contents += file.readline()
+        with open(path, 'rt') as file:
+            contents = u"".join(islice(file, 5))
             self.assertEquals(snippets[0].data, contents)
         # test middle snippet
-        with open(path,'rt') as file:
-            contents = u""
-            for i in range(7):
-                if i<2:
-                    file.readline() # advance pointer
-                    continue
-                contents += file.readline()
+        with open(path, 'rt') as file:
+            contents = u"".join(islice(file, 2, 7))
             self.assertEquals(snippets[1].data, contents)
         # test last snippet
-        with open(path,'rt') as file:
-            contents = u""
-            for i in range(8):
-                if i<3:
-                    file.readline() # advance pointer
-                    continue
-                contents += file.readline()
+        with open(path, 'rt') as file:
+            contents = u"".join(islice(file, 3, 8))
             self.assertEquals(snippets[2].data, contents)
-        
+
     def test_larger_byte_files(self):
-        path = os.path.join(self.layer.working_dir,'2','d','larger.bin')
-        with open(path,'rb') as file:
+        path = os.path.join(self.layer.working_dir, '2', 'd', 'larger.bin')
+        with open(path, 'rb') as file:
             contents = file.read()
         mf_unicode = component.createObject(
-                            u'mellon.factories.filesystem.byte_file',
-                            path,
-                            self.layer.config)
-        snippets = [s for s in mf_unicode]
-        self.assertEquals(len(snippets), 2) 
-        self.assertEquals(len(snippets[0].data), DEFAULT_read_size*DEFAULT_snippet_bytes_coverage) 
-        self.assertEquals(len(snippets[1].data), DEFAULT_read_size*DEFAULT_snippet_bytes_coverage) 
-        
-        self.assertNotEqual(snippets[0].data, snippets[1].data)
-        self.assertEquals(snippets[0].data, contents[0:DEFAULT_read_size*DEFAULT_snippet_bytes_coverage])
-        self.assertEquals(snippets[1].data, contents[-DEFAULT_read_size*DEFAULT_snippet_bytes_coverage:])
+            u'mellon.factories.filesystem.byte_file',
+            path,
+            self.layer.config)
+        snippets = list(mf_unicode)
+        self.assertEquals(len(snippets), 2)
+        self.assertEquals(len(snippets[0].data), DEFAULT_read_size * DEFAULT_snippet_bytes_coverage)
+        self.assertEquals(len(snippets[1].data), DEFAULT_read_size * DEFAULT_snippet_bytes_coverage)
 
-    
+        self.assertNotEqual(snippets[0].data, snippets[1].data)
+        self.assertEquals(snippets[0].data,
+                          contents[0:DEFAULT_read_size * DEFAULT_snippet_bytes_coverage])
+        self.assertEquals(snippets[1].data,
+                          contents[-DEFAULT_read_size * DEFAULT_snippet_bytes_coverage:])
 
     def test_largest_unicode_files(self):
-        path = os.path.join(self.layer.working_dir,'1','largest.txt')
-        with open(path,'rt') as file:
+        path = os.path.join(self.layer.working_dir, '1', 'largest.txt')
+        with open(path, 'rt') as file:
             contents = file.read()
         mf_unicode = component.createObject(
-                            u'mellon.factories.filesystem.unicode_file',
-                            path,
-                            self.layer.config)
-        snippets = [s for s in mf_unicode]
+            u'mellon.factories.filesystem.unicode_file',
+            path,
+            self.layer.config)
+        snippets = list(mf_unicode)
         self.assertEquals(len(snippets), 511)
-        
+
         # test first snippet
-        with open(path,'rt') as file:
-            contents = u""
-            for i in range(5):
-                contents += file.readline()
+        with open(path, 'rt') as file:
+            contents = u"".join(islice(file, 5))
             self.assertEquals(snippets[0].data, contents)
-        
+
         # test next to last snippet
-        with open(path,'rt') as file:
-            contents = u""
-            for i in range(1023):
-                if i<1023-5:
-                    file.readline() # advance pointer
-                    continue
-                contents += file.readline()
+        with open(path, 'rt') as file:
+            contents = u"".join(islice(file, 1023 - 5, 1023))
             self.assertEquals(snippets[509].data, contents)
 
         # test last snippet
-        with open(path,'rt') as file:
-            contents = u""
-            for i in range(1024):
-                if i<1024-5:
-                    file.readline() # advance pointer
-                    continue
-                contents += file.readline()
+        with open(path, 'rt') as file:
+            contents = u"".join(islice(file, 1024 - 5, 1024))
             self.assertEquals(snippets[510].data, contents)
 
-        
     def test_largest_byte_files(self):
-        path = os.path.join(self.layer.working_dir,'1','largest.bin')
-        with open(path,'rb') as file:
+        path = os.path.join(self.layer.working_dir, '1', 'largest.bin')
+        with open(path, 'rb') as file:
             contents = file.read()
         mf = component.createObject(
-                            u'mellon.factories.filesystem.byte_file',
-                            path,
-                            self.layer.config)
-        snippets = [s for s in mf]
-        self.assertEquals(len(snippets), 3) 
-        self.assertEquals(len(snippets[0].data), DEFAULT_read_size*DEFAULT_snippet_bytes_coverage) 
+            u'mellon.factories.filesystem.byte_file',
+            path,
+            self.layer.config)
+        snippets = list(mf)
+        self.assertEquals(len(snippets), 3)
+        self.assertEquals(len(snippets[0].data), DEFAULT_read_size * DEFAULT_snippet_bytes_coverage)
         start = 0
-        stop = DEFAULT_read_size*DEFAULT_snippet_bytes_coverage
+        stop = DEFAULT_read_size * DEFAULT_snippet_bytes_coverage
         self.assertEquals(snippets[0].data, contents[start:stop])
-        
-        self.assertEquals(len(snippets[1].data), DEFAULT_read_size*DEFAULT_snippet_bytes_coverage)
+
+        self.assertEquals(len(snippets[1].data), DEFAULT_read_size * DEFAULT_snippet_bytes_coverage)
         start = stop - DEFAULT_read_size
-        stop = start + DEFAULT_read_size*DEFAULT_snippet_bytes_coverage
+        stop = start + DEFAULT_read_size * DEFAULT_snippet_bytes_coverage
         self.assertEquals(snippets[1].data, contents[start:stop])
-        
-        self.assertEquals(len(snippets[2].data), DEFAULT_read_size*DEFAULT_snippet_bytes_coverage)
-        start = len(contents) - DEFAULT_read_size*DEFAULT_snippet_bytes_coverage
+
+        self.assertEquals(len(snippets[2].data), DEFAULT_read_size * DEFAULT_snippet_bytes_coverage)
+        start = len(contents) - DEFAULT_read_size * DEFAULT_snippet_bytes_coverage
         stop = len(contents)
         self.assertEquals(snippets[2].data, contents[start:stop])
 
@@ -191,15 +168,15 @@ class test_suite(test_suite_mixin):
     layer = MELLON_FACTORIES_FILESYSTEM_LAYER
     package = 'mellon.factories.filesystem'
     module = 'file'
-    
+
     def __new__(cls):
         suite = super(test_suite, cls).__new__(cls)
         suite.addTest(unittest.makeSuite(MellonFactoryFilesystemFileTestCase))
         return suite
 
+
 if __name__ == '__main__':
     zope.testrunner.run([
-                         '--path', os.path.dirname(__file__),
-                         '--tests-pattern', os.path.splitext(
-                                                os.path.basename(__file__))[0]
-                         ])
+        '--path', os.path.dirname(__file__),
+        '--tests-pattern', os.path.splitext(os.path.basename(__file__))[0]
+    ])


### PR DESCRIPTION
```python
# create test file
>>> with open('hmm.txt', 'w') as f:
...     for i in range(10):
...         f.write(f'{i}\n')
... 

# show islice returning the same content
>>> from itertools import islice
... 
... START = 3
... STOP = 8
... 
... with open('hmm.txt', 'r') as file:
...     contents = ''
...     for i in range(STOP):
...         if i < START:
...             file.readline()  # advance pointer
...             continue
...         contents += file.readline()
... 
... with open('hmm.txt', 'r') as f:
...     islice_contents = ''.join(islice(f, START, STOP))
... 
>>> contents == islice_contents
True
>>> islice_contents
'3\n4\n5\n6\n7\n'
```
